### PR TITLE
Room Region analysis now has the same result across multiple runs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,28 +65,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "indexmap"
-version = "2.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,17 +121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "priority-queue"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c501afe3a2e25c9bd219aa56ec1e04cdb3fcdd763055be268778c13fa82c1f"
-dependencies = [
- "autocfg",
- "equivalent",
- "indexmap",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,10 +165,9 @@ dependencies = [
 
 [[package]]
 name = "screeps-room-regions"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "itertools",
- "priority-queue",
  "screeps-game-api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ all-features = true
 
 [dependencies]
 itertools = "0.13.0"
-priority-queue = "2.0.3"
 screeps-game-api = "0.21"
 
 [features]


### PR DESCRIPTION
Changed from the non-deterministic priority_queue dependency to std::collections::BinaryHeap (which I originally didn't realize existed). This also seems to give a slight performance improvement? But it's on the order of maybe 20 microseconds, and I'd need to do stats and run across every room to be sure.

Apparently cargo also makes you increment the minor version when you remove a dependency? Or maybe that's something else, I don't really get why it keeps happening. It might be because I have this as a path local dependency.