### PR TITLE
Integrate optional graphlib dependency, add better connectivity information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Remove `priority_queue` dependency in favor of `std::collections::BinaryTree`
+- Bugfix for region lookup by `RoomXY`
+- Add border tile region adjacency information
+- Add region border tile adjacency information
+
 ## 0.1.3
 
 - Add distinct exit regions to watershed process

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "indexmap"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +153,27 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "priority-queue"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70c501afe3a2e25c9bd219aa56ec1e04cdb3fcdd763055be268778c13fa82c1f"
+dependencies = [
+ "autocfg",
+ "equivalent",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -168,6 +223,8 @@ name = "screeps-room-regions"
 version = "0.1.3"
 dependencies = [
  "itertools",
+ "petgraph",
+ "priority-queue",
  "screeps-game-api",
 ]
 
@@ -204,11 +261,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,17 +165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "priority-queue"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c501afe3a2e25c9bd219aa56ec1e04cdb3fcdd763055be268778c13fa82c1f"
-dependencies = [
- "autocfg",
- "equivalent",
- "indexmap",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,7 +213,6 @@ version = "0.1.3"
 dependencies = [
  "itertools",
  "petgraph",
- "priority-queue",
  "screeps-game-api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 itertools = "0.13.0"
 petgraph = { version = "0.6.5", optional = true }
-priority-queue = "2.0.3"
 screeps-game-api = "0.21"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ name = "screeps_room_regions"
 
 [package.metadata.docs.rs]
 all-features = true
+# this workaround (and the cfg_attr wrapping around the feature(doc_auto_cfg) call)
+# can go once the doc_auto_cfg feature is stablized
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 itertools = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,10 @@ all-features = true
 
 [dependencies]
 itertools = "0.13.0"
+petgraph = { version = "0.6.5", optional = true }
+priority-queue = "2.0.3"
 screeps-game-api = "0.21"
 
 [features]
 default = []
+petgraph = ["dep:petgraph"]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 This crate provides region analysis of rooms in the programmable MMO Screeps: World.
 
 It relies entirely on the local versions of room data, meaning it can be run both online and offline without modifications.
+
+## Planned Improvements
+
+* Expose exit tiles from room analysis
+* Expose exit regions from room analysis
+* Add border tile region adjacency aggregation and reporting
+* Add region-based border tiles reporting for adjacency checking against other regions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,16 @@
+//! Room region analysis structures and algorithms for Screeps: World.
+//!
+//! # Cargo Features
+//!
+//! ## `petgraph`
+//!
+//! Enables conversion of region analysis data into graph structures that can
+//! be operated on using [petgraph](https://docs.rs/petgraph/)-defined algorithms.
+
+// to build locally with doc_cfg enabled, run:
+// `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features`
+#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![feature(doc_cfg)]
 
 /// Used for calculating the standard distance transforms of tiles from walls
 pub mod distance_transform;

--- a/src/region_analysis/structs.rs
+++ b/src/region_analysis/structs.rs
@@ -23,24 +23,33 @@ use petgraph::prelude::UnGraphMap;
 pub struct RoomRegionAnalysis {
     regions: HashMap<RegionLabel, RoomRegion>,
     heights: TileMap<u8>,
+    xy_label_lookup: TileMap<RegionLabel>,
     borders: SegmentBorders,
     border_tiles: Vec<RoomXY>,
+    border_tile_adjacent_regions: HashMap<RoomXY, HashSet<RegionLabel>>,
+    border_tiles_for_region: HashMap<RegionLabel, HashSet<RoomXY>>,
     regions_by_color_id: HashMap<ColorIdx, RegionLabel>,
     region_neighbors: HashMap<RegionLabel, HashSet<RegionLabel>>,
-
+    exit_regions: Vec<RegionLabel>,
+    watershed: RoomRegionWatershed,
     next_region_label_value: u8,
     next_border_region_label_value: u8,
 }
 
 impl RoomRegionAnalysis {
-    fn new(borders: SegmentBorders, border_tiles: &[RoomXY]) -> Self {
+    fn new(borders: SegmentBorders, border_tiles: &[RoomXY], watershed: RoomRegionWatershed) -> Self {
         Self {
             regions: HashMap::new(),
             heights: TileMap::new(0),
+            xy_label_lookup: TileMap::new(RegionLabel::new(0)),
             borders,
             border_tiles: border_tiles.to_vec(),
+            border_tile_adjacent_regions: HashMap::new(),
+            border_tiles_for_region: HashMap::new(),
             regions_by_color_id: HashMap::new(),
             region_neighbors: HashMap::new(),
+            exit_regions: Vec::new(),
+            watershed,
             next_region_label_value: 1,
             next_border_region_label_value: 1,
         }
@@ -50,18 +59,18 @@ impl RoomRegionAnalysis {
     pub fn new_from_terrain(terrain: &LocalRoomTerrain) -> Self {
         let heights = DistanceTransform::new_chebyshev(terrain);
         let watershed = RoomRegionWatershed::new_from_distance_transform(heights);
-        let color_map = watershed.get_color_map();
-        let borders = watershed.get_borders();
-        let mut rra_obj = RoomRegionAnalysis::new(SegmentBorders::new(&color_map, &borders), borders);
+        let color_map = watershed.get_color_map().clone();
+        let borders = watershed.get_borders().clone();
+        let mut rra_obj = RoomRegionAnalysis::new(SegmentBorders::new(&color_map, &borders), &borders, watershed);
 
-        rra_obj.update_height(watershed.get_heightmap_clone());
+        rra_obj.update_height(rra_obj.watershed.get_heightmap_clone());
 
         // Get all colors, filter the borders and walls, aggregate members by region
         let mut members_by_maxima: HashMap<RoomXY, HashSet<RoomXY>> = HashMap::new();
 
         let mut maxima_by_color_id: HashMap<ColorIdx, RoomXY> = HashMap::new();
 
-        let all_maximas = watershed.get_local_maximas().iter().chain(watershed.get_exit_region_maximas());
+        let all_maximas = rra_obj.watershed.get_local_maximas().iter().chain(rra_obj.watershed.get_exit_region_maximas());
         for xy in all_maximas {
             let color = color_map[*xy];
             if let Color::Resolved(color_id) = color {
@@ -98,26 +107,59 @@ impl RoomRegionAnalysis {
             }
         }
 
-        let mut regions_to_connect: Vec<(RegionLabel, RegionLabel)> = Vec::new();
+        let exit_regions: Vec<RegionLabel> = rra_obj.watershed.get_exit_region_maximas().iter()
+            .filter_map(|xy: &RoomXY| rra_obj.get_region_for_xy(*xy))
+            .map(|region| region.get_label())
+            .unique()
+            .collect();
+
+        rra_obj.exit_regions = exit_regions;
+
+        let mut regions_to_connect: HashSet<(RegionLabel, RegionLabel)> = HashSet::new();
+        let mut border_region_adjacencies: Vec<(RoomXY, HashSet<RegionLabel>)> = Vec::new();
+
+        let mut debug_seen_region_labels: HashSet<RegionLabel> = HashSet::new();
 
         for border_xy in rra_obj.get_border_tiles() {
-            let adjacent_region_pairs: Vec<(ColorIdx, ColorIdx)> = border_xy.neighbors().iter()
+            let adjacent_regions: Vec<RegionLabel> = border_xy.neighbors().iter()
                 .filter(|xy| terrain.get_xy(**xy) != Terrain::Wall)
-                .filter_map(|xy| if let Color::Resolved(color_id) = color_map[xy] { Some(color_id) } else { None })
+                .filter(|xy| if let Color::Resolved(color_id) = color_map[*xy] { true } else { false })
+                .filter_map(|xy| rra_obj.get_region_for_xy(*xy))
+                .map(|region| region.get_label())
                 .unique()
+                .collect();
+
+            let mut entry: HashSet<RegionLabel> = HashSet::new();
+            for label in &adjacent_regions {
+                entry.insert(*label);
+                debug_seen_region_labels.insert(*label);
+            }
+
+            border_region_adjacencies.push((*border_xy, entry));
+
+            let adjacent_region_pairs: Vec<(RegionLabel, RegionLabel)> = adjacent_regions.into_iter()
                 .combinations(2)
                 .map(|v| (v[0], v[1]))
                 .collect();
 
-            for (a, b) in adjacent_region_pairs {
-                let label_a = rra_obj.get_region_for_color_id(a).expect("expected a region").get_label();
-                let label_b = rra_obj.get_region_for_color_id(b).expect("expected a region").get_label();
-                regions_to_connect.push((label_a, label_b));
+            for (label_a, label_b) in adjacent_region_pairs {
+                regions_to_connect.insert((label_a, label_b));
             }
         }
 
         for (a, b) in regions_to_connect {
             rra_obj.connect_regions(a, b);
+        }
+
+        for label in rra_obj.regions.keys() {
+            rra_obj.border_tiles_for_region.insert(*label, HashSet::new());
+        }
+
+        for (xy, entry) in border_region_adjacencies {
+            for label in entry.iter() {
+                rra_obj.border_tiles_for_region.entry(*label).or_insert_with(|| HashSet::new()).insert(xy);
+            }
+            rra_obj.border_tile_adjacent_regions.insert(xy, entry);
         }
 
         rra_obj
@@ -129,6 +171,9 @@ impl RoomRegionAnalysis {
         let region = RoomRegion::new(label, members, local_maximum, color_id);
         self.regions.insert(label, region);
         self.regions_by_color_id.insert(color_id, label);
+        for xy in members {
+            self.xy_label_lookup[xy] = label;
+        }
         label
     }
 
@@ -150,10 +195,14 @@ impl RoomRegionAnalysis {
         self.regions.values().collect()
     }
 
+    pub fn get_exit_regions(&self) -> Vec<&RoomRegion> {
+        self.exit_regions.iter().map(|label| &self.regions[label]).collect()
+    }
+
     /// Get the region for a specific `RoomXY` coordinate
     pub fn get_region_for_xy(&self, xy: RoomXY) -> Option<&RoomRegion> {
-        let label_val = self.heights[xy];
-        self.regions.get(&RegionLabel::new(label_val))
+        let label = self.xy_label_lookup[xy];
+        self.regions.get(&label)
     }
 
     /// Get the region for a specific color ID
@@ -177,30 +226,17 @@ impl RoomRegionAnalysis {
         &self.border_tiles
     }
 
+    pub fn get_border_tiles_for_region(&self, region: RegionLabel) -> &HashSet<RoomXY> {
+        &self.border_tiles_for_region[&region]
+    }
+
+    pub fn get_watershed(&self) -> &RoomRegionWatershed {
+        &self.watershed
+    }
+
     /// Generates a region adjacency graph, mapping every region (identified by its
     /// `RegionLabel`) to every adjacent region.
     pub fn get_regions_graph_as_hashmap(&self) -> &HashMap<RegionLabel, HashSet<RegionLabel>> {
-        // let mut graph: HashMap<RegionLabel, HashSet<RegionLabel>> = HashMap::new();
-
-        // for label in self.regions.keys() {
-        //     graph.insert(*label, HashSet::new());
-        // }
-
-        // for (color_a, color_b, _) in self.borders.iter() {
-        //     if let Some(label_a) = self.regions_by_color_id.get(&color_a) {
-        //         if let Some(label_b) = self.regions_by_color_id.get(&color_b) {
-        //             if let Some(mut edges_a) = graph.get_mut(label_a) {
-        //                 edges_a.insert(*label_b);
-        //             }
-        //             if let Some(mut edges_b) = graph.get_mut(label_b) {
-        //                 edges_b.insert(*label_a);
-        //             }
-        //         }
-        //     }
-        // }
-
-        // graph
-
         &self.region_neighbors
     }
 

--- a/src/region_analysis/structs.rs
+++ b/src/region_analysis/structs.rs
@@ -118,8 +118,6 @@ impl RoomRegionAnalysis {
         let mut regions_to_connect: HashSet<(RegionLabel, RegionLabel)> = HashSet::new();
         let mut border_region_adjacencies: Vec<(RoomXY, HashSet<RegionLabel>)> = Vec::new();
 
-        let mut debug_seen_region_labels: HashSet<RegionLabel> = HashSet::new();
-
         for border_xy in rra_obj.get_border_tiles() {
             let adjacent_regions: Vec<RegionLabel> = border_xy.neighbors().iter()
                 .filter(|xy| terrain.get_xy(**xy) != Terrain::Wall)
@@ -132,7 +130,6 @@ impl RoomRegionAnalysis {
             let mut entry: HashSet<RegionLabel> = HashSet::new();
             for label in &adjacent_regions {
                 entry.insert(*label);
-                debug_seen_region_labels.insert(*label);
             }
 
             border_region_adjacencies.push((*border_xy, entry));

--- a/src/region_analysis/watershed.rs
+++ b/src/region_analysis/watershed.rs
@@ -16,6 +16,7 @@ use screeps::constants::extra::ROOM_SIZE;
 const ROOM_AREA: usize = (ROOM_SIZE as usize) * (ROOM_SIZE as usize);
 
 /// Stores data from a maxima-based Meyer's Floodfill Algorithm.
+#[derive(Debug)]
 pub struct RoomRegionWatershed {
     heights: DistanceTransform,
     local_maximas: Vec<RoomXY>,
@@ -23,10 +24,11 @@ pub struct RoomRegionWatershed {
     num_colors: ColorIdx,
     borders: Vec<RoomXY>,
     exit_region_maximas: Vec<RoomXY>,
+    exit_region_groups: Vec<Vec<RoomXY>>,
 }
 
 impl RoomRegionWatershed {
-    fn new(heights: DistanceTransform, local_maximas: &[RoomXY], color_map: TileMap<Color>, num_colors: ColorIdx, borders: &[RoomXY], exit_region_maximas: &[RoomXY]) -> Self {
+    fn new(heights: DistanceTransform, local_maximas: &[RoomXY], color_map: TileMap<Color>, num_colors: ColorIdx, borders: &[RoomXY], exit_region_maximas: &[RoomXY], exit_region_groups: Vec<Vec<RoomXY>>) -> Self {
         Self {
             heights,
             local_maximas: local_maximas.to_vec(),
@@ -34,6 +36,7 @@ impl RoomRegionWatershed {
             num_colors,
             borders: borders.to_vec(),
             exit_region_maximas: exit_region_maximas.to_vec(),
+            exit_region_groups: exit_region_groups,
         }
     }
 
@@ -59,6 +62,7 @@ impl RoomRegionWatershed {
             num_colors: color_count,
             borders,
             exit_region_maximas: exit_region_maximas,
+            exit_region_groups: exit_groups,
         }
     }
 
@@ -87,6 +91,10 @@ impl RoomRegionWatershed {
     /// Gets a list of the local maximas across the exit regions
     pub fn get_exit_region_maximas(&self) -> &Vec<RoomXY> {
         &self.exit_region_maximas
+    }
+
+    pub fn get_exit_region_groups(&self) -> &Vec<Vec<RoomXY>> {
+        &self.exit_region_groups
     }
 }
 


### PR DESCRIPTION
This update integrates an optional graph library (`petgraph`) dependency, so that we can expose region analysis data in formal graph format that can then be used by end-users for further analysis (ford-fulkerson, printing to Graphviz Dot format, etc.).

This update also adds better border connectivity data, and exposes more of the underlying datasets for better visibility and review by an end-user.