### PR TITLE
Bugfix: Remove local maxima placement on exit region borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bugfix for region lookup by `RoomXY`
 - Add border tile region adjacency information
 - Add region border tile adjacency information
+- Bugfix for border tile region maxima placement
 
 ## 0.1.3
 


### PR DESCRIPTION
This update fixes an edge case where non-exit region local maxima could be located on tiles that are guaranteed to be border tiles for exit regions.